### PR TITLE
Update Test-FolderTasks to support recursion, and limit the files evaluated to json by default

### DIFF
--- a/src/tsqlScheduler/Public/Test-FolderTasks.ps1
+++ b/src/tsqlScheduler/Public/Test-FolderTasks.ps1
@@ -5,11 +5,13 @@ Function Test-FolderTasks
     [Parameter(Mandatory=$true)]
     [ValidateScript({ Test-Path -Path $PSItem })]
     [ValidateNotNullOrEmpty()]
-    [string] $FolderPath
+    [string] $FolderPath,
+
+    [switch] $Recurse
   )
   $result = $true
 
-  $rawFiles = Get-ChildItem -Path $FolderPath -File
+  $rawFiles = Get-ChildItem -Path $FolderPath -File -Recurse:$Recurse
 
   foreach($rawFile in $rawFiles) {
     $content = Get-Content -LiteralPath $rawFile -Raw 

--- a/src/tsqlScheduler/Public/Test-FolderTasks.ps1
+++ b/src/tsqlScheduler/Public/Test-FolderTasks.ps1
@@ -9,7 +9,7 @@ Function Test-FolderTasks
   )
   $result = $true
 
-  $rawFiles = Get-ChildItem -Path $FolderPath
+  $rawFiles = Get-ChildItem -Path $FolderPath -File
 
   foreach($rawFile in $rawFiles) {
     $content = Get-Content -LiteralPath $rawFile -Raw 

--- a/src/tsqlScheduler/Public/Test-FolderTasks.ps1
+++ b/src/tsqlScheduler/Public/Test-FolderTasks.ps1
@@ -7,11 +7,13 @@ Function Test-FolderTasks
     [ValidateNotNullOrEmpty()]
     [string] $FolderPath,
 
-    [switch] $Recurse
+    [switch] $Recurse,
+
+    [string] $Filter = "*.json"
   )
   $result = $true
 
-  $rawFiles = Get-ChildItem -Path $FolderPath -File -Recurse:$Recurse
+  $rawFiles = Get-ChildItem -Path $FolderPath -File -Recurse:$Recurse -Filter $Filter
 
   foreach($rawFile in $rawFiles) {
     $content = Get-Content -LiteralPath $rawFile -Raw 


### PR DESCRIPTION
The old version of this command had a few issues:
- By default it would test everything in a folder (directories, `.gitignore`, etc.)
- Didn't support recursion
- Didn't support filtering

The new default is checks the current folder for `*.json` files only.  Supports override via the `Filter` parameter, and recursion via the `Recurse` switch. 