### PR TITLE
Update CreateJobFromTask.sql to conditionally execute task

### DIFF
--- a/src/tsqlScheduler/SQL/Procedures/CreateJobFromTask.sql
+++ b/src/tsqlScheduler/SQL/Procedures/CreateJobFromTask.sql
@@ -52,7 +52,9 @@ begin
   from  scheduler.GetInstanceId() as id
   for json path, without_array_wrapper)
   
-  set @command = 'exec ' + @db + '.scheduler.ExecuteTask @taskUid = ''' + cast(@taskUid as varchar(36)) + ''';';
+  set @command
+       = N'if databasepropertyex(''' + @db + ''',''Updateability'') = ''READ_WRITE'' exec ' + @db + N'.scheduler.ExecuteTask @taskUid = '''
+       + cast (@taskUid as varchar(36)) + N''';';
 
   exec scheduler.CreateAgentJob
       @taskUid = @taskUid


### PR DESCRIPTION
Update this proc to execute the task only when the db is available for read/writes. Mainly to support inaccessible / non-readable AG databases.